### PR TITLE
Publish view pointing to most recent model version

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -21,6 +21,8 @@ clean-targets:         # directories to be removed by `dbt clean`
   - "dbt_packages"
 
 models:
+  post-hook:
+    - "{{ create_latest_version_view() }}"
   mozdbt:
     moz-fx-data-shared-prod:
       +on_schema_change: "append_new_columns"

--- a/macros/create_latest_version_view.sql
+++ b/macros/create_latest_version_view.sql
@@ -1,0 +1,29 @@
+-- https://docs.getdbt.com/docs/collaborate/govern/model-versions#how-is-this-different-from-just-creating-a-new-model
+{% macro create_latest_version_view() %}
+    -- this hook will run only if the model is versioned, and only if it's the latest version
+    -- otherwise, it's a no-op
+    {% if model.get('version') and model.get('version') == model.get('latest_version') and config.get('publish_view') %}
+        -- publish view in non-derived dataset
+        {% set new_relation = this.incorporate(path={"identifier": model['name'], "schema": model["schema"].replace("_derived", "")}) %}
+
+        {% set existing_relation = load_relation(new_relation) %}
+
+        {% if existing_relation and not existing_relation.is_view %}
+            {{ drop_relation_if_exists(existing_relation) }}
+        {% endif %}
+        
+        {% set create_view_sql -%}
+            -- this syntax may vary by data platform
+            CREATE OR REPLACE VIEW {{ new_relation }}
+            AS SELECT * FROM {{ this }}
+        {%- endset %}
+        
+        {% do log("Creating view " ~ new_relation ~ " pointing to " ~ this, info = true) if execute %}
+        
+        {{ return(create_view_sql) }}
+        
+    {% else %}
+        -- no-op
+        select 1 as id
+    {% endif %}
+{% endmacro %}

--- a/models/business_models/product/newtab/newtab.yml
+++ b/models/business_models/product/newtab/newtab.yml
@@ -2,3 +2,7 @@ models:
   - name: newtab_visits
     latest_version: 1
     description: Visits on the newtab page, one row per visit per-day (identified by the visit id).
+    versions:
+      - v: 1
+    config:
+      publish_view: true


### PR DESCRIPTION
This adds a macro to publish views that point to the most recent version of a model.
It's based on the recommendation in the dbt docs: https://docs.getdbt.com/docs/collaborate/govern/model-versions#how-is-this-different-from-just-creating-a-new-model

Publishing views for models can be configured via the model `.yml` file:

```yaml
    config:
      publish_view: true/false
```

Our data warehouse has `_derived` datasets and corresponding datasets without the `_derived` postfix. The latter datasets generally consist of views pointing to the most recent version of a table. This ensures that nothing should break for users if a version is updated. Also these views are made available to the `mozdata` project (but not the `_derived` tables).