### PR TITLE
Apply labels and metadata to map BigQuery tables back to dbt

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -11,7 +11,7 @@ profile: 'mozdbt'
 model-paths: ["models"]
 analysis-paths: ["analysis"]
 test-paths: ["tests"]
-data-paths: ["data"]
+seed-paths: ["seeds"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 
@@ -23,10 +23,13 @@ clean-targets:         # directories to be removed by `dbt clean`
 models:
   post-hook:
     - "{{ create_latest_version_view() }}"
+    - "{{ apply_metadata() }}"
   mozdbt:
     moz-fx-data-shared-prod:
       +on_schema_change: "append_new_columns"
       +materialized: incremental
+      +labels:
+        repo: mozdbt
       business_models:
         +persist_docs:
           relation: true

--- a/macros/apply_metadata.sql
+++ b/macros/apply_metadata.sql
@@ -1,0 +1,9 @@
+{% macro apply_metadata() %}
+
+  ALTER TABLE {{ this }} 
+  SET OPTIONS (
+    description = "{{ model.get('description', '') }}" || "\n\nhttps://github.com/mozilla/mozdbt/blob/main/models/" || "{{ model.path }}"
+  )
+
+  {% do log("Apply metadata to" ~ this, info = true) if execute %}
+{% endmacro %}

--- a/macros/create_latest_version_view.sql
+++ b/macros/create_latest_version_view.sql
@@ -15,7 +15,11 @@
         {% set create_view_sql -%}
             -- this syntax may vary by data platform
             CREATE OR REPLACE VIEW {{ new_relation }}
-            AS SELECT * FROM {{ this }}
+            AS SELECT * FROM {{ this }};
+              ALTER TABLE {{ this }} 
+              SET OPTIONS (
+                description = "{{ model.get('description', '') }}" || "\n\nhttps://github.com/mozilla/mozdbt/blob/main/models/" || "{{ model.path }}"
+              )
         {%- endset %}
         
         {% do log("Creating view " ~ new_relation ~ " pointing to " ~ this, info = true) if execute %}

--- a/macros/create_latest_version_view.sql
+++ b/macros/create_latest_version_view.sql
@@ -15,11 +15,10 @@
         {% set create_view_sql -%}
             -- this syntax may vary by data platform
             CREATE OR REPLACE VIEW {{ new_relation }}
-            AS SELECT * FROM {{ this }};
-              ALTER TABLE {{ this }} 
-              SET OPTIONS (
-                description = "{{ model.get('description', '') }}" || "\n\nhttps://github.com/mozilla/mozdbt/blob/main/models/" || "{{ model.path }}"
-              )
+            OPTIONS (
+                description="{{ model.get('description', '') }}" || "\n\nhttps://github.com/mozilla/mozdbt/blob/main/models/" || "{{ model.path }}"
+            )
+            AS SELECT * FROM {{ this }}
         {%- endset %}
         
         {% do log("Creating view " ~ new_relation ~ " pointing to " ~ this, info = true) if execute %}


### PR DESCRIPTION
This PR adds a new macro which will add the path to the model file to the table description. This should make it easier to find the model file when looking at table metadata and addresses some of the questions of:

_What mechanisms of organization do we have? How can that be leveraged to improve find-ability of data assets?
Should we use labels or a naming convention to designate the source of the table/view?_

The path can't be added as label since it includes characters that are not supported as labels