### PR TITLE
setup: DENG-3716 - local dev environment v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ venv/
 dbt_modules/
 dbt_packages/
 *.DS_Store
+profiles.yml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+setup:
+		bin/generate_profiles

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # mozdbt
 Mozilla dbt models
+
+## Local Development (dbt-core)
+
+To create your `profiles.yml` file, run `make setup`

--- a/bin/generate_profiles
+++ b/bin/generate_profiles
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eo pipefail
+
+USERNAME=$(gcloud config get-value account | awk -F"@" '{print $1}')
+USERDATASET=dbt_$USERNAME
+sed "s/user_dataset/$USERDATASET/g" profiles.tmpl.yml | tee profiles.yml

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -25,17 +25,16 @@ models:
     - "{{ create_latest_version_view() }}"
     - "{{ apply_metadata() }}"
   mozdbt:
-    moz-fx-data-shared-prod:
-      +on_schema_change: "append_new_columns"
-      +materialized: incremental
-      +labels:
-        repo: mozdbt
-      business_models:
-        +persist_docs:
-          relation: true
-          columns: true
-        product:
-          firefox_desktop:
-            +schema: telemetry_derived
-          newtab:
-            +schema: analysis  # todo: change
+    +on_schema_change: "append_new_columns"
+    +materialized: incremental
+    +labels:
+      repo: mozdbt
+    business_models:
+      +persist_docs:
+        relation: true
+        columns: true
+      product:
+        firefox_desktop:
+          +schema: telemetry_derived
+        newtab:
+          +schema: analysis  # todo: change

--- a/macros/get_custom_schema.sql
+++ b/macros/get_custom_schema.sql
@@ -1,0 +1,3 @@
+{% macro generate_schema_name(custom_schema_name, node) -%}
+    {{ generate_schema_name_for_env(custom_schema_name, node) }}
+{%- endmacro %}

--- a/models/business_models/product/newtab/newtab_visits_v1.sql
+++ b/models/business_models/product/newtab/newtab_visits_v1.sql
@@ -30,7 +30,8 @@ WITH events_unnested AS (
     `moz-fx-data-shared-prod.firefox_desktop_stable.newtab_v1`,
     UNNEST(events)
   WHERE
-    category IN ('newtab', 'topsites', 'newtab.search', 'newtab.search.ad', 'pocket')
+    normalized_channel = 'nightly'
+    AND category IN ('newtab', 'topsites', 'newtab.search', 'newtab.search.ad', 'pocket')
     AND name IN (
       'closed',
       'opened',
@@ -41,7 +42,7 @@ WITH events_unnested AS (
       'topic_click',
       'dismiss'
     )
-    AND DATE(submission_timestamp) > "2024-03-30" -- limit backfill
+    AND DATE(submission_timestamp) > DATE_SUB(CURRENT_DATE(), INTERVAL 3 DAY) -- limit backfill
     {% if is_incremental() %}
     AND DATE(submission_timestamp) > (SELECT max(submission_date) FROM {{ this }} WHERE submission_date > '2020-01-01')
     {% endif %}

--- a/profiles.tmpl.yml
+++ b/profiles.tmpl.yml
@@ -1,13 +1,13 @@
 mozdbt:
   outputs:
     dev:
-      dataset: tmp
+      dataset: user_dataset
       job_execution_timeout_seconds: 300
       job_retries: 1
       location: US
       method: oauth
       priority: interactive
-      project: "{{ env_var('PROJECT_ID', 'moz-fx-data-shared-prod') }}"
+      project: moz-fx-data-shar-nonprod-efed
       threads: 1
       type: bigquery
   target: dev


### PR DESCRIPTION
This PR does a few things for setting up the local (dbt-core) dev environment 

Creates a script that defines the user's profile. 
`profiles.yaml` needs a target dataset. In order to have each person's dev dataset in shared-nonprod be setup we can version control a profiles template and have each person run a script to create it once they clone the repository. This won't be necessary in dbt cloud since you configure your dev dataset in the UI. 

Adds macro for overriding schema specification in the dev environment.
From [these docs](https://docs.getdbt.com/docs/build/custom-schemas#a-built-in-alternative-pattern-for-generating-schema-names) users will create models always in the target schema (their dev dataset) in dev. In prod the custom schemas will apply. 

Tangential: limit the source data for creating the model to nightly and a few days 